### PR TITLE
Update README with GitHub authentication steps

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -11,9 +11,14 @@ npm install jspm
 jspm install
 python -m SimpleHTTPServer
 ```
-
 Then navigate to `http://localhost:8000`
 
+### Configure GitHub authentication
+If you get an error saying: `GitHub rate limit reached. To increase the limit use GitHub authentication`, you will need to set up GitHub authentication by following these steps:
+
+- Create a new [personal access token](https://github.com/settings/applications#personal-access-tokens) for your GitHub account
+- Run `jspm registry config github` and provide your username and access token when prompted
+- Re-run `jspm install`
 
 ## To make a new quiz:
 * tag the master branch
@@ -22,7 +27,7 @@ Then navigate to `http://localhost:8000`
 * update quizId in component.jsx so the stats go to the right place
 
 ## To make sure you can deploy a quiz
-* make sure you have brew install s3cmd
+* make sure you have `s3cmd` installed (`brew install s3cmd`)
 * make sure you have an s3 key for the interactives bucket
 
 ## to deploy a quiz


### PR DESCRIPTION
I got caught out on GitHub authentication for `jspm` when setting this up earlier so thought it might be worth adding a note to the README.